### PR TITLE
Show pending mempool stakes for awaiting SNs

### DIFF
--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -241,3 +241,9 @@ td span.checkpoint-not-signed { color: #c50022; }
 .omg {
     font-weight: bold;
 }
+
+.pending-mempool-stakes .tx {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/templates/service_node_detail.html
+++ b/src/templates/service_node_detail.html
@@ -90,4 +90,26 @@
         </tr>
         {{/service_node_contributors}}
     </table>
+
+    {{#pending_stakes_size}}
+    <h2>{{pending_stakes_size}} pending mempool contribution(s)</h2>
+    <div class="TitleDivider"></div>
+
+    <table style="width:100%" class="pending-mempool-stakes">
+        <tr class="TableHeader">
+            <td>Contributor</td>
+            <td class="tx">TX</td>
+            <td>Amount</td>
+        </tr>
+
+        {{#pending_stakes}}
+        <tr>
+            <td>{{address}}</td>
+            <td class="tx"><a href="/tx/{{txid}}">{{txid}}</a></td>
+            <td>{{amount}}</td>
+        </tr>
+        {{/pending_stakes}}
+    </table>
+    {{/pending_stakes_size}}
+
 </div>


### PR DESCRIPTION
When showing a single, awaiting-contributions service node query the mempool for pending transactions and show any found.

Credit for the idea to @CryptoFirefly (in https://github.com/loki-project/loki/issues/747#issuecomment-512717517)

![image](https://user-images.githubusercontent.com/4459524/61499509-e21cab00-a99d-11e9-84f6-57bafd0ddc2d.png)
