### PR TITLE
Add emojis to identify transaction types

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -6851,9 +6851,15 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             // deregistration transparently).
             tx_extra_service_node_state_change state_change;
             context["is_state_change"] = true;
-
+#if 1
+            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
+            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
+               if (new_style)
+                    context["state_change_new_style"] = true;
+#else
             if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
                 context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
+#endif
                 context["state_change_service_node_index"] = state_change.service_node_index;
                 context["state_change_block_height"] = state_change.block_height;
                 context[

--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -247,3 +247,7 @@ td span.checkpoint-not-signed { color: #c50022; }
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.TXType {
+  font-family: initial;
+}

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -54,6 +54,8 @@
         </p>
     {{/network_info}}
 
+    <p>TX Types Legend: Recommission: &#x1F44D; | Decommission: &#x1F44E; | Deregister: &#x1F6AB; | IP Change Penalty: &#x1F4CB; | Stake Unlock: &#x1F513;</p>
+
     {{#emission}}
         <p style="margin-top: 2px">
             Circulating Supply: {{circulating_supply}}
@@ -84,6 +86,7 @@
                 <td>Height</td>
                 <td>Age {{age_format}}<!--(Δm)--></td>
                 <td>Size [kB]<!--(Δm)--></td>
+                <td>Type</td>
                 <td>Transaction Hash</td>
                 <td>Fee</td>
                 <td>Outputs</td>
@@ -95,6 +98,7 @@
                 <td><a href="/block/{{height}}">{{height}}</a></td>
                 <td>{{age}}<!--{{time_delta}}--></td>
                 <td>{{blk_size}}</td>
+                <td class="TXType">{{tx_type}}</td>
                 <td><a href="/tx/{{hash}}">{{hash}}</a></td>
                 <td>{{tx_fee_short}}</td>
                 <td>{{sum_outputs_short}}</td>

--- a/src/templates/mempool.html
+++ b/src/templates/mempool.html
@@ -7,6 +7,7 @@
        <table style="width:100%">
           <tr class="TableHeader">
               <td>Age [HH:MM:SS]</td>
+              <td>Type</td>
               <td>Transaction Hash</td>
               <td>Fee/Per kB</td>
               <!--<td>outputs</td>-->
@@ -16,6 +17,7 @@
           {{#mempooltxs}}
           <tr>
               <td>{{age}}</td>
+              <td class=TXType>{{tx_type}}</td>
               <td><a href="/tx/{{hash}}">{{hash}}</a></td>
               <td>{{fee}}/{{payed_for_kB}}</td>
               <!--<td>{{lok_outputs}}</td>-->

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -31,7 +31,7 @@
         {{^have_raw_tx}}
         <tr>
             <td>Timestamp: {{blk_timestamp_uint}}</td>
-            <td>Timestamp [UCT]: {{blk_timestamp}}</td>
+            <td>Timestamp [UTC]: {{blk_timestamp}}</td>
             <td>Age [y:d:h:m:s]: {{delta_time}}</td>
         </tr>
         {{/have_raw_tx}}
@@ -44,9 +44,12 @@
         <tr>
             <td>TX Version: {{tx_version}}</td>
             <td>No Of Confirmations: {{confirmations}}</td>
-            <td>RingCT/Type:  {{#is_ringct}}Yes/{{rct_type}}{{/is_ringct}}{{^is_ringct}}No{{/is_ringct}}</td>
+            <td>RingCT/RingCT Type:  {{#is_ringct}}Yes/{{rct_type}}{{/is_ringct}}{{^is_ringct}}No{{/is_ringct}}</td>
         </tr>
 
+        <tr>
+          <td>TX Type: {{tx_type_emoji}} {{tx_type}}</td>
+        </tr>
 
         <tr>
             <td colspan="3" style="max-width:700px;word-wrap:break-word;">Extra: {{extra}}</td>


### PR DESCRIPTION
Adds a new table column for tx type and use emojis to identify the type. In tx details, additionally add the type stringified. 

Looks something like
![emojis_on_explorer](https://user-images.githubusercontent.com/12163539/61845476-bd1cc080-aee6-11e9-9b95-d52257440d8f.png)
