### PR TITLE
Add emojis for transaction type

### DIFF
--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -248,15 +248,15 @@ MempoolStatus::read_network_info()
     if (!rpc.get_network_info(rpc_network_info))
         return false;
 
-    uint64_t fee_estimated;
+    uint64_t fee_estimated_per_byte, fee_estimated_per_out;
 
     string error_msg;
 
-    if (!rpc.get_dynamic_per_kb_fee_estimate(
+    if (!rpc.get_fee_estimate(
             FEE_ESTIMATE_GRACE_BLOCKS,
-            fee_estimated, error_msg))
+            fee_estimated_per_byte, fee_estimated_per_out, error_msg))
     {
-        cerr << "rpc.get_dynamic_per_kb_fee_estimate failed" << endl;
+        cerr << "rpc.get_fee_estimate failed" << endl;
         return false;
     }
 
@@ -315,7 +315,8 @@ MempoolStatus::read_network_info()
     epee::string_tools::hex_to_pod(rpc_network_info.top_block_hash,
                                    local_copy.top_block_hash);
 
-    local_copy.fee_per_kb                 = fee_estimated;
+    local_copy.fee_per_byte               = fee_estimated_per_byte;
+    local_copy.fee_per_out                = fee_estimated_per_out;
     local_copy.info_timestamp             = static_cast<uint64_t>(std::time(nullptr));
 
     local_copy.current_hf_version         = rpc_hardfork_info.version;

--- a/src/MempoolStatus.h
+++ b/src/MempoolStatus.h
@@ -88,7 +88,8 @@ struct MempoolStatus
         uint64_t current_hf_version {0};
 
         uint64_t hash_rate  {0};
-        uint64_t fee_per_kb  {0};
+        uint64_t fee_per_byte {0};
+        uint64_t fee_per_out {0};
         uint64_t info_timestamp  {0};
         uint64_t staking_requirement {0};
         uint64_t total_blockchain_size {0};

--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -52,7 +52,7 @@ MicroCore::init(const string& _blockchain_path, network_type nt)
     try
     {
         // try opening lmdb database files
-        db->open(blockchain_path, db_flags);
+        db->open(blockchain_path, nettype,  db_flags);
     }
     catch (const std::exception& e)
     {

--- a/src/page.h
+++ b/src/page.h
@@ -976,6 +976,7 @@ void add_tx_service_node_metadata(mstch::map &context, const cryptonote::transac
     if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
     {
         tx_extra_service_node_register     register_;
+        tx_extra_tx_key_image_unlock       unlock_;
         cryptonote::account_public_address contributor;
         if (tx.type == cryptonote::txtype::state_change)
         {
@@ -1037,6 +1038,15 @@ void add_tx_service_node_metadata(mstch::map &context, const cryptonote::transac
             }
             else {
                 context["state_change_unknown"] = std::string{"unknown"};
+            }
+        }
+        else if (tx.type == cryptonote::txtype::key_image_unlock && get_tx_key_image_unlock_from_tx_extra(tx.extra, unlock_))
+        {
+            context["have_unlock_info"] = true;
+            context["unlock_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
+            if (detailed) {
+                context["unlock_key_image"] = pod_to_hex(unlock_.key_image);
+                context["unlock_signature"] = pod_to_hex(unlock_.signature);
             }
         }
         else if (get_service_node_register_from_tx_extra(tx.extra, register_))

--- a/src/page.h
+++ b/src/page.h
@@ -38,7 +38,7 @@
 
 
 #define TMPL_DIR                    "./templates"
-#define TMPL_PARIALS_DIR            TMPL_DIR "/partials"
+#define TMPL_PARTIALS_DIR           TMPL_DIR "/partials"
 #define TMPL_CSS_STYLES             TMPL_DIR "/css/style.css"
 #define TMPL_INDEX                  TMPL_DIR "/index.html"
 #define TMPL_INDEX2                 TMPL_DIR "/index2.html"
@@ -412,6 +412,8 @@ string js_html_files_all_in_one;
 // read operation in OS
 map<string, string> template_file;
 
+map<string, string> partials;
+
 
 // alias for easy class typing
 template <typename Key, typename Value>
@@ -516,9 +518,11 @@ page(MicroCore* _mcore,
     template_file["checkoutputkeys"] = get_full_page(lokeg::read(TMPL_MY_CHECKRAWOUTPUTKEYS));
     template_file["address"]         = get_full_page(lokeg::read(TMPL_ADDRESS));
     template_file["search_results"]  = get_full_page(lokeg::read(TMPL_SEARCH_RESULTS));
-    template_file["tx_details"]      = lokeg::read(string(TMPL_PARIALS_DIR) + "/tx_details.html");
-    template_file["tx_table_header"] = lokeg::read(string(TMPL_PARIALS_DIR) + "/tx_table_header.html");
-    template_file["tx_table_row"]    = lokeg::read(string(TMPL_PARIALS_DIR) + "/tx_table_row.html");
+
+    partials["tx_details"]      = lokeg::read(string(TMPL_PARTIALS_DIR) + "/tx_details.html");
+    partials["tx_table_head"]   = lokeg::read(string(TMPL_PARTIALS_DIR) + "/tx_table_header.html");
+    partials["tx_table_row"]    = lokeg::read(string(TMPL_PARTIALS_DIR) + "/tx_table_row.html");
+    partials["tx_type_symbol"]  = lokeg::read(string(TMPL_PARTIALS_DIR) + "/tx_type_symbol.html");
 
     if (enable_js) {
         // JavaScript files
@@ -964,26 +968,128 @@ render_checkpoints_html(bool add_header_and_footer)
     return mstch::render(template_file["checkpoints_full"], page_context);
 }
 
-static std::string tx_type_to_emoji(cryptonote::transaction const &tx, uint8_t hf_version)
-{
-  std::string result;
-  if (tx.type == cryptonote::txtype::state_change)
-  {
-    tx_extra_service_node_state_change state_change;
-    if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, hf_version))
+// Populates the given context with service node metadata from the tx (such as state change type,
+// registration info, etc.).  If detailed is true we query a bunch of extra info (quorum info,
+// detailed registration info, etc.), otherwise we just add basic info about the type of
+// transaction.
+void add_tx_service_node_metadata(mstch::map &context, const cryptonote::transaction &tx, bool detailed = false) {
+    if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
     {
-      if (state_change.state == service_nodes::new_state::deregister) result = "\xF0\x9F\x9A\xAB"; // no entry
-      if (state_change.state == service_nodes::new_state::decommission) result = "\xF0\x9F\x91\x8E"; // thumbs down
-      if (state_change.state == service_nodes::new_state::recommission) result = "\xF0\x9F\x91\x8D"; // thumbs up
-      if (state_change.state == service_nodes::new_state::ip_change_penalty) result = "\xF0\x9F\x93\x8B"; // clipboard
-    }
-  }
-  else if (tx.type == cryptonote::txtype::key_image_unlock)
-  {
-    result = "\xF0\x9F\x94\x93"; // open lock
-  }
+        tx_extra_service_node_register     register_;
+        cryptonote::account_public_address contributor;
+        if (tx.type == cryptonote::txtype::state_change)
+        {
+            // Getting the hard fork version here is a bit tricker, so just try with v12 then if it
+            // fails, try with v11 instead (to capture older deregs).  Both still give back a
+            // state_change (for the older deregs, it translates the dereg_old into a state_change
+            // deregistration transparently).
+            tx_extra_service_node_state_change state_change;
+            context["is_state_change"] = true;
+#if 1
+            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
+            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
+               if (new_style)
+                    context["state_change_new_style"] = true;
+#else
+            if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
+                context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
+#endif
+                context["state_change_service_node_index"] = state_change.service_node_index;
+                context["state_change_block_height"] = state_change.block_height;
+                context[
+                    state_change.state == service_nodes::new_state::deregister ? "state_change_deregister" :
+                    state_change.state == service_nodes::new_state::decommission ? "state_change_decommission" :
+                    state_change.state == service_nodes::new_state::recommission ? "state_change_recommission" :
+                    state_change.state == service_nodes::new_state::ip_change_penalty ? "state_change_ip_change_penalty" :
+                    "state_change_unknown"] = true;
 
-  return result;
+                if (detailed) {
+                    // Try to get the quorum state to figure out the vote casters & target; unless very
+                    // recent, this requires lokid to be started with --store-quorum-history (PR #702)
+                    std::vector<std::string> quorum_nodes;
+                    COMMAND_RPC_GET_QUORUM_STATE::response response = {};
+                    rpc.get_quorum_state(response, state_change.block_height, state_change.block_height, static_cast<uint8_t>(service_nodes::quorum_type::obligations));
+
+                    if (response.status == "OK" && !response.quorums.empty()) {
+                        auto &quorum = response.quorums[0].quorum;
+                        if (state_change.service_node_index < quorum.workers.size())
+                            context["state_change_service_node_pubkey"] = quorum.workers[state_change.service_node_index];
+                        quorum_nodes = std::move(quorum.validators);
+                        context["state_change_have_pubkey_info"] = true;
+                    }
+
+                    auto &vote_array = get<mstch::array>(context.emplace("state_change_vote_array", mstch::array()).first->second);
+                    vote_array.reserve(state_change.votes.size());
+
+                    for (const auto &vote : state_change.votes)
+                    {
+                        mstch::map entry
+                        {
+                            {"state_change_voters_quorum_index", vote.validator_index},
+                            {"state_change_signature",           pod_to_hex(vote.signature)},
+                        };
+                        if (vote.validator_index < quorum_nodes.size())
+                            entry["state_change_voter_pubkey"] = quorum_nodes[vote.validator_index];
+
+                        vote_array.push_back(std::move(entry));
+                    }
+                }
+            }
+            else {
+                context["state_change_unknown"] = std::string{"unknown"};
+            }
+        }
+        else if (get_service_node_register_from_tx_extra(tx.extra, register_))
+        {
+            // TODO(doyle): We should add a url for jumping to the node,
+            // maybe. We only have information about the current state of
+            // the network, so previous expired nodes no longer can be
+            // accessed. This needs the store to db functionality.
+            // likewise for contributions, below.
+
+            context["have_register_info"]             = true;
+            context["register_service_node_pubkey"]   = extract_sn_pubkey(tx.extra);
+            context["register_portions_for_operator"] = portions_to_percent(register_.m_portions_for_operator);
+
+            if (detailed) {
+                context["register_expiration_timestamp_friendly"]  = timestamp_to_str_gm(register_.m_expiration_timestamp);
+                context["register_expiration_timestamp_relative"]  = get_human_time_ago(register_.m_expiration_timestamp, time(nullptr));
+                context["register_expiration_timestamp"]  = register_.m_expiration_timestamp;
+                context["register_signature"]             = pod_to_hex(register_.m_service_node_signature);
+
+                auto &array = get<mstch::array>(context.emplace("register_array", mstch::array()).first->second);
+                array.reserve(register_.m_public_spend_keys.size());
+
+                for (size_t i = 0; i < register_.m_public_spend_keys.size(); ++i)
+                {
+                  crypto::public_key const &spend_key = register_.m_public_spend_keys[i];
+                  crypto::public_key const &view_key =  register_.m_public_view_keys[i];
+                  auto portion = register_.m_portions[i];
+
+                  account_public_address address = {};
+                  address.m_spend_public_key     = spend_key;
+                  address.m_view_public_key      = view_key;
+
+                  mstch::map entry
+                  {
+                    {"register_address", get_account_address_as_str(nettype, false /*is_subaddress*/, address)},
+                    {"register_portions", portions_to_percent(portion)},
+                  };
+
+                  array.push_back(entry);
+                }
+            }
+        }
+        else if (get_service_node_contributor_from_tx_extra(tx.extra, contributor))
+        {
+			context["have_contribution_info"]           = true;
+			context["contribution_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
+			context["contribution_address"]             = get_account_address_as_str(nettype, false /*is_subaddress*/, contributor);
+
+            uint64_t amount = get_amount_from_stake(tx, contributor);
+            context["contribution_amount"] = amount > 0 ? lokeg::lok_amount_to_str(amount, "{:0.9f}", true) : "<decode error>";
+        }
+    }
 }
 
 /**
@@ -1260,7 +1366,6 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
                 txd_map.insert({"is_ringct" , tx.version >= cryptonote::txversion::v2_ringct});
                 txd_map.insert({"rct_type"  , tx.rct_signatures.type});
                 txd_map.insert({"blk_size"  , blk_size_str});
-                txd_map.insert({"tx_type"   , tx_type_to_emoji(tx, blk.major_version)});
 
 
                 // do not show block info for other than first tx in a block
@@ -1270,6 +1375,8 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
                     txd_map["age"]        = string("");
                     txd_map["blk_size"]   = string("");
                 }
+
+                add_tx_service_node_metadata(txd_map, tx);
 
                 txd_pairs.emplace_back(txd.hash, txd_map);
 
@@ -1423,7 +1530,7 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
     add_css_style(context);
 
     // render the page
-    return mstch::render(template_file["index2"], context);
+    return mstch::render(template_file["index2"], context, partials);
 }
 
 /**
@@ -1506,11 +1613,10 @@ mempool(bool add_header_and_footer = false, uint64_t no_of_mempool_tx = 25)
         // cout << "block_tx_json_cache from cache" << endl;
 
         // set output page template map
-        txs.push_back(mstch::map {
+        mstch::map context{
                 {"timestamp_no"    , mempool_tx.receive_time},
                 {"timestamp"       , mempool_tx.timestamp_str},
                 {"age"             , age_str},
-                {"tx_type"         , tx_type_to_emoji(mempool_tx.tx, MempoolStatus::current_network_info.load().current_hf_version)},
                 {"hash"            , pod_to_hex(mempool_tx.tx_hash)},
                 {"fee"             , mempool_tx.fee_str},
                 {"payed_for_kB"    , mempool_tx.payed_for_kB_str},
@@ -1522,7 +1628,11 @@ mempool(bool add_header_and_footer = false, uint64_t no_of_mempool_tx = 25)
                 {"no_nonrct_inputs", mempool_tx.num_nonrct_inputs},
                 {"mixin"           , mempool_tx.mixin_no},
                 {"txsize"          , mempool_tx.txsize}
-        });
+        };
+
+        add_tx_service_node_metadata(context, mempool_tx.tx);
+
+        txs.push_back(std::move(context));
     }
 
     context.insert({"mempool_size_kB",
@@ -2090,10 +2200,6 @@ show_tx(string tx_hash_str, uint16_t with_ring_signatures = 0)
     };
 
     boost::get<mstch::array>(context["txs"]).push_back(tx_context);
-
-    map<string, string> partials {
-            {"tx_details", template_file["tx_details"]},
-    };
 
     add_css_style(context);
 
@@ -3812,10 +3918,6 @@ show_checkrawtx(string raw_tx_data, string action)
 
             boost::get<mstch::array>(context["txs"]).push_back(tx_context);
 
-            map<string, string> partials {
-                    {"tx_details", template_file["tx_details"]},
-            };
-
             add_css_style(context);
 
             if (enable_js)
@@ -4067,10 +4169,6 @@ show_checkrawtx(string raw_tx_data, string action)
 
     }
 
-
-    map<string, string> partials {
-            {"tx_details", template_file["tx_details"]},
-    };
 
     // render the page
     return mstch::render(full_page, context, partials);
@@ -5049,12 +5147,6 @@ show_search_results(const string& search_text,
 
     // add header and footer
     string full_page = template_file["search_results"];
-
-    // read partial for showing details of tx(s) found
-    map<string, string> partials {
-            {"tx_table_head", template_file["tx_table_header"]},
-            {"tx_table_row" , template_file["tx_table_row"]}
-    };
 
     add_css_style(context);
 
@@ -6829,7 +6921,6 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"tx_json"               , tx_json},
             {"is_ringct"             , tx.version >= cryptonote::txversion::v2_ringct},
             {"tx_type"               , string(cryptonote::transaction::type_to_string(tx.type))},
-            {"tx_type_emoji"         , tx_type_to_emoji(tx, blk.major_version)},
             {"rct_type"              , tx.rct_signatures.type},
             {"has_error"             , false},
             {"error_msg"             , string("")},
@@ -6839,125 +6930,7 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"construction_time"     , string {}},
     };
 
-    if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
-    {
-        tx_extra_service_node_register     register_;
-        cryptonote::account_public_address contributor;
-        if (tx.type == cryptonote::txtype::state_change)
-        {
-            // Getting the hard fork version here is a bit tricker, so just try with v12 then if it
-            // fails, try with v11 instead (to capture older deregs).  Both still give back a
-            // state_change (for the older deregs, it translates the dereg_old into a state_change
-            // deregistration transparently).
-            tx_extra_service_node_state_change state_change;
-            context["is_state_change"] = true;
-#if 1
-            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
-            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
-               if (new_style)
-                    context["state_change_new_style"] = true;
-#else
-            if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
-                context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
-#endif
-                context["state_change_service_node_index"] = state_change.service_node_index;
-                context["state_change_block_height"] = state_change.block_height;
-                context[
-                    state_change.state == service_nodes::new_state::deregister ? "state_change_deregister" :
-                    state_change.state == service_nodes::new_state::decommission ? "state_change_decommission" :
-                    state_change.state == service_nodes::new_state::recommission ? "state_change_recommission" :
-                    state_change.state == service_nodes::new_state::ip_change_penalty ? "state_change_ip_change_penalty" :
-                    "state_change_unknown"] = true;
-
-                std::vector<std::string> quorum_nodes;
-                // Try to get the quorum state to figure out the vote casters & target; unless very
-                // recent, this requires lokid to be started with --store-quorum-history (PR #702)
-                {
-                    COMMAND_RPC_GET_QUORUM_STATE::response response = {};
-                    rpc.get_quorum_state(response, state_change.block_height, state_change.block_height, static_cast<uint8_t>(service_nodes::quorum_type::obligations));
-                    if (response.status == "OK" && !response.quorums.empty()) {
-                        auto &quorum = response.quorums[0].quorum;
-                        if (state_change.service_node_index < quorum.workers.size())
-                            context["state_change_service_node_pubkey"] = quorum.workers[state_change.service_node_index];
-                        quorum_nodes = std::move(quorum.validators);
-                        context["state_change_have_pubkey_info"] = true;
-                    }
-                }
-
-                char const vote_array_id[] = "state_change_vote_array";
-                context.emplace(vote_array_id, mstch::array());
-
-                mstch::array& vote_array = boost::get<mstch::array>(context[vote_array_id]);
-                vote_array.reserve(state_change.votes.size());
-
-                for (tx_extra_service_node_state_change::vote &vote : state_change.votes)
-                {
-                    mstch::map entry
-                    {
-                        {"state_change_voters_quorum_index", vote.validator_index},
-                        {"state_change_signature",           pod_to_hex(vote.signature)},
-                    };
-                    if (vote.validator_index < quorum_nodes.size())
-                        entry["state_change_voter_pubkey"] = quorum_nodes[vote.validator_index];
-
-                    vote_array.push_back(entry);
-                }
-            }
-            else {
-                context["state_change_unknown"] = std::string{"unknown"};
-            }
-        }
-        else if (get_service_node_register_from_tx_extra(tx.extra, register_))
-        {
-            // TODO(doyle): We should add a url for jumping to the node,
-            // maybe. We only have information about the current state of
-            // the network, so previous expired nodes no longer can be
-            // accessed. This needs the store to db functionality.
-            // likewise for contributions, below.
-
-            context["have_register_info"]             = true;
-            context["register_service_node_pubkey"]   = extract_sn_pubkey(tx.extra);
-            context["register_portions_for_operator"] = portions_to_percent(register_.m_portions_for_operator);
-            context["register_expiration_timestamp_friendly"]  = timestamp_to_str_gm(register_.m_expiration_timestamp);
-            context["register_expiration_timestamp_relative"]  = get_human_time_ago(register_.m_expiration_timestamp, time(nullptr));
-            context["register_expiration_timestamp"]  = register_.m_expiration_timestamp;
-            context["register_signature"]             = pod_to_hex(register_.m_service_node_signature);
-
-            char const array_id[] = "register_array";
-            context.emplace(array_id, mstch::array());
-
-            mstch::array& array = boost::get<mstch::array>(context[array_id]);
-            array.reserve(register_.m_public_spend_keys.size());
-
-            for (size_t i = 0; i < register_.m_public_spend_keys.size(); ++i)
-            {
-              crypto::public_key const &spend_key = register_.m_public_spend_keys[i];
-              crypto::public_key const &view_key =  register_.m_public_view_keys[i];
-              auto portion = register_.m_portions[i];
-
-              account_public_address address = {};
-              address.m_spend_public_key     = spend_key;
-              address.m_view_public_key      = view_key;
-
-              mstch::map entry
-              {
-                {"register_address", get_account_address_as_str(nettype, false /*is_subaddress*/, address)},
-                {"register_portions", portions_to_percent(portion)},
-              };
-
-              array.push_back(entry);
-            }
-        }
-        else if (get_service_node_contributor_from_tx_extra(tx.extra, contributor))
-        {
-			context["have_contribution_info"]           = true;
-			context["contribution_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
-			context["contribution_address"]             = get_account_address_as_str(nettype, false /*is_subaddress*/, contributor);
-
-            uint64_t amount = get_amount_from_stake(tx, contributor);
-            context["contribution_amount"] = amount > 0 ? lokeg::lok_amount_to_str(amount, "{:0.9f}", true) : "<decode error>";
-        }
-    }
+    add_tx_service_node_metadata(context, tx, true /*detailed*/);
 
     // append tx_json as in raw format to html
     context["tx_json_raw"] = mstch::lambda{[=](const std::string& text) -> mstch::node {

--- a/src/page.h
+++ b/src/page.h
@@ -6851,9 +6851,15 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             // deregistration transparently).
             tx_extra_service_node_state_change state_change;
             context["is_state_change"] = true;
-
+#if 1
+            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
+            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
+               if (new_style)
+                    context["state_change_new_style"] = true;
+#else
             if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
                 context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
+#endif
                 context["state_change_service_node_index"] = state_change.service_node_index;
                 context["state_change_block_height"] = state_change.block_height;
                 context[

--- a/src/page.h
+++ b/src/page.h
@@ -1658,7 +1658,7 @@ mempool(bool add_header_and_footer = false, uint64_t no_of_mempool_tx = 25)
     context["partial_mempool_shown"] = true;
 
     // render the page
-    return mstch::render(template_file["mempool"], context);
+    return mstch::render(template_file["mempool"], context, partials);
 }
 
 

--- a/src/page.h
+++ b/src/page.h
@@ -1657,7 +1657,7 @@ mempool(bool add_header_and_footer = false, uint64_t no_of_mempool_tx = 25)
         context["partial_mempool_shown"] = false;
 
         // render the page
-        return mstch::render(template_file["mempool_full"], context);
+        return mstch::render(template_file["mempool_full"], context, partials);
     }
 
     // this is for partial disply on front page.

--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -330,9 +330,10 @@ rpccalls::get_hardfork_info(COMMAND_RPC_HARD_FORK_INFO::response& response)
 
 
 bool
-rpccalls::get_dynamic_per_kb_fee_estimate(
+rpccalls::get_fee_estimate(
         uint64_t grace_blocks,
-        uint64_t& fee,
+        uint64_t& fee_per_byte,
+        uint64_t& fee_per_out,
         string& error_msg)
 {
     epee::json_rpc::request<COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request>
@@ -353,7 +354,7 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
 
         if (!connect_to_loki_daemon())
         {
-            cerr << "get_dynamic_per_kb_fee_estimate: not connected to daemon" << endl;
+            cerr << "get_fee_estimate: not connected to daemon" << endl;
             return false;
         }
 
@@ -390,7 +391,8 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
         return false;
     }
 
-    fee = resp_t.result.fee;
+    fee_per_byte = resp_t.result.fee_per_byte;
+    fee_per_out = resp_t.result.fee_per_output;
 
     return true;
 }

--- a/src/rpccalls.h
+++ b/src/rpccalls.h
@@ -106,9 +106,10 @@ public:
     get_hardfork_info( COMMAND_RPC_HARD_FORK_INFO::response& res);
 
     bool
-    get_dynamic_per_kb_fee_estimate(
+    get_fee_estimate(
             uint64_t grace_blocks,
-            uint64_t& fee,
+            uint64_t& fee_per_byte,
+            uint64_t& fee_per_out,
             string& error_msg);
 
 

--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -247,3 +247,7 @@ td span.checkpoint-not-signed { color: #c50022; }
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.TXType {
+  font-family: initial;
+}

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -54,7 +54,7 @@
         </p>
     {{/network_info}}
 
-    <p>TX Types Legend: Recommission: &#x1F44D; | Decommission: &#x1F44E; | Deregister: &#x1F6AB; | IP Change Penalty: &#x1F4CB; | Stake Unlock: &#x1F513;</p>
+    <p>TX Types Legend: Registration: 🏁 | Contribution: ⚑ | Recommission: 👍 | Decommission: 👎 | Deregister: 🚫 | IP Change Penalty: 📋 | Stake Unlock: 🔓</p>
 
     {{#emission}}
         <p style="margin-top: 2px">
@@ -98,7 +98,7 @@
                 <td><a href="/block/{{height}}">{{height}}</a></td>
                 <td>{{age}}<!--{{time_delta}}--></td>
                 <td>{{blk_size}}</td>
-                <td class="TXType">{{tx_type}}</td>
+                <td class="TXType">{{>tx_type_symbol}}</td>
                 <td><a href="/tx/{{hash}}">{{hash}}</a></td>
                 <td>{{tx_fee_short}}</td>
                 <td>{{sum_outputs_short}}</td>

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -45,7 +45,7 @@
             | Hard fork: v{{current_hf_version}}
             | Hash rate: {{hash_rate}}
             | Staking Requirement: {{staking_requirement}}
-            | Fee per byte: {{fee_per_kb}}
+            | Fee: {{fee_per_byte}}/byte + {{fee_per_output}}/output
             | Median block size limit: {{block_size_limit}} kB
             | Total blockchain size: {{total_blockchain_size}} GB
             {{^is_current_info}}

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -54,6 +54,8 @@
         </p>
     {{/network_info}}
 
+    <p>TX Types Legend: Recommission: &#x1F44D; | Decommission: &#x1F44E; | Deregister: &#x1F6AB; | IP Change Penalty: &#x1F4CB; | Stake Unlock: &#x1F513;</p>
+
     {{#emission}}
         <p style="margin-top: 2px">
             Circulating Supply: {{circulating_supply}}
@@ -84,6 +86,7 @@
                 <td>Height</td>
                 <td>Age {{age_format}}<!--(Δm)--></td>
                 <td>Size [kB]<!--(Δm)--></td>
+                <td>Type</td>
                 <td>Transaction Hash</td>
                 <td>Fee</td>
                 <td>Outputs</td>
@@ -95,6 +98,7 @@
                 <td><a href="/block/{{height}}">{{height}}</a></td>
                 <td>{{age}}<!--{{time_delta}}--></td>
                 <td>{{blk_size}}</td>
+                <td class="TXType">{{tx_type}}</td>
                 <td><a href="/tx/{{hash}}">{{hash}}</a></td>
                 <td>{{tx_fee_short}}</td>
                 <td>{{sum_outputs_short}}</td>

--- a/src/templates/mempool.html
+++ b/src/templates/mempool.html
@@ -17,7 +17,7 @@
           {{#mempooltxs}}
           <tr>
               <td>{{age}}</td>
-              <td class=TXType>{{tx_type}}</td>
+              <td class=TXType>{{>tx_type_symbol}}</td>
               <td><a href="/tx/{{hash}}">{{hash}}</a></td>
               <td>{{fee}}/{{payed_for_kB}}</td>
               <!--<td>{{lok_outputs}}</td>-->

--- a/src/templates/mempool.html
+++ b/src/templates/mempool.html
@@ -7,6 +7,7 @@
        <table style="width:100%">
           <tr class="TableHeader">
               <td>Age [HH:MM:SS]</td>
+              <td>Type</td>
               <td>Transaction Hash</td>
               <td>Fee/Per kB</td>
               <!--<td>outputs</td>-->
@@ -16,6 +17,7 @@
           {{#mempooltxs}}
           <tr>
               <td>{{age}}</td>
+              <td class=TXType>{{tx_type}}</td>
               <td><a href="/tx/{{hash}}">{{hash}}</a></td>
               <td>{{fee}}/{{payed_for_kB}}</td>
               <!--<td>{{lok_outputs}}</td>-->

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -130,6 +130,13 @@
         <p>Contribution Amount: {{contribution_amount}} LOKI</p>
     {{/have_contribution_info}}
 
+    {{#have_unlock_info}}
+        <h2>Service Node Unlock</h2>
+        <p class="unlock-pubkey">Service Node Public Key: <a href="/service_node/{{unlock_service_node_pubkey}}">{{unlock_service_node_pubkey}}</a></p>
+        <p>Unlock key image: {{unlock_key_image}}</p>
+        <p>Unlock signature: {{unlock_signature}}</p>
+    {{/have_unlock_info}}
+
 
   <h2>Outputs</h2>
   <h4 class="Subtitle">{{outputs_no}} output(s) for total of {{outputs_lok_sum}} lok</h4>

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -31,7 +31,7 @@
         {{^have_raw_tx}}
         <tr>
             <td>Timestamp: {{blk_timestamp_uint}}</td>
-            <td>Timestamp [UCT]: {{blk_timestamp}}</td>
+            <td>Timestamp [UTC]: {{blk_timestamp}}</td>
             <td>Age [y:d:h:m:s]: {{delta_time}}</td>
         </tr>
         {{/have_raw_tx}}
@@ -44,9 +44,12 @@
         <tr>
             <td>TX Version: {{tx_version}}</td>
             <td>No Of Confirmations: {{confirmations}}</td>
-            <td>RingCT/Type:  {{#is_ringct}}Yes/{{rct_type}}{{/is_ringct}}{{^is_ringct}}No{{/is_ringct}}</td>
+            <td>RingCT/RingCT Type:  {{#is_ringct}}Yes/{{rct_type}}{{/is_ringct}}{{^is_ringct}}No{{/is_ringct}}</td>
         </tr>
 
+        <tr>
+          <td>TX Type: {{tx_type_emoji}} {{tx_type}}</td>
+        </tr>
 
         <tr>
             <td colspan="3" style="max-width:700px;word-wrap:break-word;">Extra: {{extra}}</td>

--- a/src/templates/partials/tx_type_symbol.html
+++ b/src/templates/partials/tx_type_symbol.html
@@ -1,0 +1,7 @@
+{{#state_change_decommission}}<span title="Service Node decommission">👎</span>{{/state_change_decommission}}
+{{#state_change_recommission}}<span title="Service Node recommission">👍</span>{{/state_change_recommission}}
+{{#state_change_deregister}}<span title="Service Node deregistration">🚫</span>{{/state_change_deregister}}
+{{#state_change_ip_change_penalty}}<span title="Service Node IP change penalty">📋</span>{{/state_change_ip_change_penalty}}
+{{#state_change_unlock}}<span title="Service Node stake unlock">🔓</span>{{/state_change_unlock}}
+{{#have_register_info}}<span title="Service Node registration">🏁</span>{{/have_register_info}}
+{{#have_contribution_info}}<span title="Service Node contribution">⚑</span>{{/have_contribution_info}}

--- a/src/templates/partials/tx_type_symbol.html
+++ b/src/templates/partials/tx_type_symbol.html
@@ -2,6 +2,6 @@
 {{#state_change_recommission}}<span title="Service Node recommission">👍</span>{{/state_change_recommission}}
 {{#state_change_deregister}}<span title="Service Node deregistration">🚫</span>{{/state_change_deregister}}
 {{#state_change_ip_change_penalty}}<span title="Service Node IP change penalty">📋</span>{{/state_change_ip_change_penalty}}
-{{#state_change_unlock}}<span title="Service Node stake unlock">🔓</span>{{/state_change_unlock}}
+{{#have_unlock_info}}<span title="Service Node stake unlock">🔓</span>{{/have_unlock_info}}
 {{#have_register_info}}<span title="Service Node registration">🏁</span>{{/have_register_info}}
 {{#have_contribution_info}}<span title="Service Node contribution">⚑</span>{{/have_contribution_info}}

--- a/src/templates/partials/tx_type_symbol.html
+++ b/src/templates/partials/tx_type_symbol.html
@@ -2,6 +2,6 @@
 {{#state_change_recommission}}<span title="Service Node recommission">👍</span>{{/state_change_recommission}}
 {{#state_change_deregister}}<span title="Service Node deregistration">🚫</span>{{/state_change_deregister}}
 {{#state_change_ip_change_penalty}}<span title="Service Node IP change penalty">📋</span>{{/state_change_ip_change_penalty}}
-{{#have_unlock_info}}<span title="Service Node stake unlock">🔓</span>{{/have_unlock_info}}
-{{#have_register_info}}<span title="Service Node registration">🏁</span>{{/have_register_info}}
-{{#have_contribution_info}}<span title="Service Node contribution">⚑</span>{{/have_contribution_info}}
+{{#have_unlock_info}}<span title="Service Node stake unlock — {{unlock_service_node_pubkey}}">🔓</span>{{/have_unlock_info}}
+{{#have_register_info}}<span title="Service Node registration — {{register_service_node_pubkey}}">🏁</span>{{/have_register_info}}
+{{#have_contribution_info}}<span title="Service Node contribution – {{contribution_service_node_pubkey}}">⚑</span>{{/have_contribution_info}}


### PR DESCRIPTION
This pulls in the emoji additions Doyle's branch but rearranged a bit to keep the emoji content in the templates rather than the code.  It also adds flags for registration and contributions, and simplifies some duplicated logic to extract SN metadata.

This PR also adds mouseover title tags to the emoji and shows pubkeys in the mouseover for register/stake/unlock emoji.