### PR TITLE
Loki v5 updates

### DIFF
--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -248,15 +248,15 @@ MempoolStatus::read_network_info()
     if (!rpc.get_network_info(rpc_network_info))
         return false;
 
-    uint64_t fee_estimated;
+    uint64_t fee_estimated_per_byte, fee_estimated_per_out;
 
     string error_msg;
 
-    if (!rpc.get_dynamic_per_kb_fee_estimate(
+    if (!rpc.get_fee_estimate(
             FEE_ESTIMATE_GRACE_BLOCKS,
-            fee_estimated, error_msg))
+            fee_estimated_per_byte, fee_estimated_per_out, error_msg))
     {
-        cerr << "rpc.get_dynamic_per_kb_fee_estimate failed" << endl;
+        cerr << "rpc.get_fee_estimate failed" << endl;
         return false;
     }
 
@@ -315,7 +315,8 @@ MempoolStatus::read_network_info()
     epee::string_tools::hex_to_pod(rpc_network_info.top_block_hash,
                                    local_copy.top_block_hash);
 
-    local_copy.fee_per_kb                 = fee_estimated;
+    local_copy.fee_per_byte               = fee_estimated_per_byte;
+    local_copy.fee_per_out                = fee_estimated_per_out;
     local_copy.info_timestamp             = static_cast<uint64_t>(std::time(nullptr));
 
     local_copy.current_hf_version         = rpc_hardfork_info.version;

--- a/src/MempoolStatus.h
+++ b/src/MempoolStatus.h
@@ -88,7 +88,8 @@ struct MempoolStatus
         uint64_t current_hf_version {0};
 
         uint64_t hash_rate  {0};
-        uint64_t fee_per_kb  {0};
+        uint64_t fee_per_byte {0};
+        uint64_t fee_per_out {0};
         uint64_t info_timestamp  {0};
         uint64_t staking_requirement {0};
         uint64_t total_blockchain_size {0};

--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -52,7 +52,7 @@ MicroCore::init(const string& _blockchain_path, network_type nt)
     try
     {
         // try opening lmdb database files
-        db->open(blockchain_path, db_flags);
+        db->open(blockchain_path, nettype,  db_flags);
     }
     catch (const std::exception& e)
     {

--- a/src/page.h
+++ b/src/page.h
@@ -1327,7 +1327,8 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
     context["network_info"] = mstch::map {
             {"difficulty"         , lokeg::make_comma_sep_number(current_network_info.difficulty)},
             {"hash_rate"          , hash_rate},
-            {"fee_per_kb"         , print_money(current_network_info.fee_per_kb)},
+            {"fee_per_byte"       , print_money(current_network_info.fee_per_byte)},
+            {"fee_per_output"     , print_money(current_network_info.fee_per_out)},
             {"alt_blocks_no"      , current_network_info.alt_blocks_count},
             {"have_alt_block"     , (current_network_info.alt_blocks_count > 0)},
             {"tx_pool_size"       , current_network_info.tx_pool_size},
@@ -6311,17 +6312,18 @@ json_networkinfo()
         return j_response;
     }
 
-    uint64_t fee_estimated {0};
+    uint64_t fee_estimated_per_byte{0}, fee_estimated_per_out{0};
 
     // get dynamic fee estimate from last 10 blocks
-    if (!get_dynamic_per_kb_fee_estimate(fee_estimated))
+    if (!get_fee_estimate(fee_estimated_per_byte, fee_estimated_per_out))
     {
         j_response["status"]  = "error";
         j_response["message"] = "Cant get dynamic fee esimate";
         return j_response;
     }
 
-    j_info["fee_per_kb"] = fee_estimated;
+    j_info["fee_per_byte"] = fee_estimated_per_byte;
+    j_info["fee_per_output"] = fee_estimated_per_out;
 
     j_info["tx_pool_size"]        = MempoolStatus::mempool_no.load();
     j_info["tx_pool_size_kbytes"] = MempoolStatus::mempool_size.load();
@@ -7584,7 +7586,8 @@ get_loki_network_info(json& j_info)
        {"block_size_limit"          , local_copy_network_info.block_size_limit},
        {"block_size_median"         , local_copy_network_info.block_size_median},
        {"start_time"                , local_copy_network_info.start_time},
-       {"fee_per_kb"                , local_copy_network_info.fee_per_kb},
+       {"fee_per_byte"              , local_copy_network_info.fee_per_byte},
+       {"fee_per_output"            , local_copy_network_info.fee_per_out},
        {"current_hf_version"        , local_copy_network_info.current_hf_version},
        {"total_blockchain_size"     , local_copy_network_info.total_blockchain_size}
     };
@@ -7593,16 +7596,16 @@ get_loki_network_info(json& j_info)
 }
 
 bool
-get_dynamic_per_kb_fee_estimate(uint64_t& fee_estimated)
+get_fee_estimate(uint64_t &fee_estimated_per_byte, uint64_t &fee_estimated_per_out)
 {
 
     string error_msg;
 
-    if (!rpc.get_dynamic_per_kb_fee_estimate(
+    if (!rpc.get_fee_estimate(
             FEE_ESTIMATE_GRACE_BLOCKS,
-            fee_estimated, error_msg))
+            fee_estimated_per_byte, fee_estimated_per_out, error_msg))
     {
-        cerr << "rpc.get_dynamic_per_kb_fee_estimate failed" << endl;
+        cerr << "rpc.get_fee_estimate failed" << endl;
         return false;
     }
 

--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -330,9 +330,10 @@ rpccalls::get_hardfork_info(COMMAND_RPC_HARD_FORK_INFO::response& response)
 
 
 bool
-rpccalls::get_dynamic_per_kb_fee_estimate(
+rpccalls::get_fee_estimate(
         uint64_t grace_blocks,
-        uint64_t& fee,
+        uint64_t& fee_per_byte,
+        uint64_t& fee_per_out,
         string& error_msg)
 {
     epee::json_rpc::request<COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request>
@@ -353,7 +354,7 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
 
         if (!connect_to_loki_daemon())
         {
-            cerr << "get_dynamic_per_kb_fee_estimate: not connected to daemon" << endl;
+            cerr << "get_fee_estimate: not connected to daemon" << endl;
             return false;
         }
 
@@ -390,7 +391,8 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
         return false;
     }
 
-    fee = resp_t.result.fee;
+    fee_per_byte = resp_t.result.fee_per_byte;
+    fee_per_out = resp_t.result.fee_per_output;
 
     return true;
 }

--- a/src/rpccalls.h
+++ b/src/rpccalls.h
@@ -106,9 +106,10 @@ public:
     get_hardfork_info( COMMAND_RPC_HARD_FORK_INFO::response& res);
 
     bool
-    get_dynamic_per_kb_fee_estimate(
+    get_fee_estimate(
             uint64_t grace_blocks,
-            uint64_t& fee,
+            uint64_t& fee_per_byte,
+            uint64_t& fee_per_out,
             string& error_msg);
 
 

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -45,7 +45,7 @@
             | Hard fork: v{{current_hf_version}}
             | Hash rate: {{hash_rate}}
             | Staking Requirement: {{staking_requirement}}
-            | Fee per byte: {{fee_per_kb}}
+            | Fee: {{fee_per_byte}}/byte + {{fee_per_output}}/output
             | Median block size limit: {{block_size_limit}} kB
             | Total blockchain size: {{total_blockchain_size}} GB
             {{^is_current_info}}


### PR DESCRIPTION
- Adds per-byte/per-output fee support
- Fix for API change in db->open needing `nettype` passed in