### PR TITLE
Add unlock symbol to service node lists

### DIFF
--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -24,8 +24,10 @@
               <td>{{staking_requirement}}</td>
               <td>{{last_reward_at_block}}</td>
               <td>{{last_uptime_proof}}</td>
-              <td>
-                  {{#expiration_date}}{{expiration_date}} ({{expiration_time_relative}}){{/expiration_date}}
+              <td>{{#expiration_date}}
+                    <span title="Service Node unlock in progress">🔓</span>
+                    {{expiration_date}} ({{expiration_time_relative}})
+                  {{/expiration_date}}
                   {{^expiration_date}}Staking Infinitely{{/expiration_date}}
               </td>
           </tr>
@@ -94,7 +96,13 @@
               <td>{{total_contributed}}</td>
               <td>{{total_reserved}}</td>
               <td>{{staking_requirement}}</td>
-              <td>{{expiration_date}} ({{expiration_time_relative}})</td>
+              <td>{{#expiration_date}}
+                    <span title="Service Node unlock in progress">🔓</span>
+                    {{expiration_date}} ({{expiration_time_relative}})
+                  {{/expiration_date}}
+                  {{^expiration_date}}Staking Infinitely{{/expiration_date}}
+              </td>
+
           </tr>
           {{/service_nodes_awaiting}}
           {{#service_nodes_awaiting_more}}


### PR DESCRIPTION
(I thought I had already submitted this PR last week but apparently not.)

This was requested in particular for the Awaiting list to make it stand out a little more that a node that is open for stakes but also undergoing an unlocking.

This also unifies the Awaiting expiry date with the regular date to show "Staking Infinitely" instead of "()".