### PR TITLE
Service node display rearrangement

### DIFF
--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -248,6 +248,10 @@ td span.checkpoint-not-signed { color: #c50022; }
     text-overflow: ellipsis;
 }
 
+h3 .sn-count {
+    font-weight: bold;
+}
+
 .TXType {
   font-family: initial;
 }

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -1,8 +1,11 @@
 
 <div class="Wrapper">
     <div class="TitleDivider"></div>
-    <h2 style="margin-bottom: 0px">Service Nodes</h2>
-    <h4 class="Subtitle">(No. of active Service Nodes: {{service_nodes_active_size}})</h4>
+    <h1 style="margin-bottom: 0px">Service Nodes</h1>
+    <h3><span class="sn-count">{{service_nodes_active_size}}</span> active service nodes,
+        <span class="sn-count">{{service_nodes_inactive_size}}</span> decommissioned service nodes,
+        and <span class="sn-count">{{service_nodes_awaiting_size}}</span> service nodes awaiting contributions.</h3>
+    <h2 style="margin-bottom: 0px">Active Service Nodes <span class="sn-count">({{service_nodes_active_size}})</span></h2>
     <div class="TitleDivider sn-active"></div>
 
       <table style="width:100%">
@@ -39,9 +42,9 @@
           {{/service_nodes_active_more}}
       </table>
 
-    <h2 style="margin-bottom: 0px" id="service-nodes-inactive">Inactive/Decommissioned Service Nodes</h2>
-    <h4 class="Subtitle">(These {{service_nodes_inactive_size}} service nodes are currently <span style="font-weight: bold; text-decoration: underline">not earning rewards</span> and face deregistration soon)</h4>
-    <div class="TitleDivider sn-inactive"></div>
+      <h2 style="margin-bottom: 0px" id="service-nodes-inactive">Inactive/Decommissioned Service Nodes <span class="sn-count">({{service_nodes_inactive_size}})</span></h2>
+      <h4 class="Subtitle">(These service nodes are currently decommissioned for failing network obligations, <span style="font-weight: bold; text-decoration: underline">are not earning rewards</span>, and face deregistration soon)</h4>
+      <div class="TitleDivider sn-inactive"></div>
 
       <table style="width:100%">
           <tr class="TableHeader">
@@ -71,8 +74,7 @@
           {{/service_nodes_inactive_more}}
       </table>
 
-      <h2 style="margin-bottom: 0px" id="service-nodes-awaiting">Service Nodes Awaiting</h2>
-      <h4 class="Subtitle">(No. of Service Nodes awaiting contribution: {{service_nodes_awaiting_size}})</h4>
+      <h2 style="margin-bottom: 0px" id="service-nodes-awaiting">Service Nodes Awaiting Contributions <span class="sn-count">({{service_nodes_awaiting_size}})</span></h2>
       <div class="TitleDivider sn-awaiting"></div>
 
       <table style="width:100%">

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -84,7 +84,6 @@
               <td>Operator Fee (%)</td>
               <td>Open For Contribution</td>
               <td>Contributed</td>
-              <td>Reserved</td>
               <td>Staking Requirement</td>
               <td>Expiry Date UTC (Estimated)</td>
           </tr>
@@ -103,7 +102,6 @@
               <td>{{open_for_contribution}}</td>
               {{/only_reserved_spots}}
               <td>{{total_contributed}}</td>
-              <td>{{total_reserved}}</td>
               <td>{{staking_requirement}}</td>
               <td>{{#expiration_date}}
                     <span title="Service Node unlock in progress">🔓</span>

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -2,77 +2,9 @@
 <div class="Wrapper">
     <div class="TitleDivider"></div>
     <h1 style="margin-bottom: 0px">Service Nodes</h1>
-    <h3><span class="sn-count">{{service_nodes_active_size}}</span> active service nodes,
+    <h3><span class="sn-count">{{service_nodes_awaiting_size}}</span> service nodes awaiting contributions,
         <span class="sn-count">{{service_nodes_inactive_size}}</span> decommissioned service nodes,
-        and <span class="sn-count">{{service_nodes_awaiting_size}}</span> service nodes awaiting contributions.</h3>
-    <h2 style="margin-bottom: 0px">Active Service Nodes <span class="sn-count">({{service_nodes_active_size}})</span></h2>
-    <div class="TitleDivider sn-active"></div>
-
-      <table style="width:100%">
-          <tr class="TableHeader">
-              <td>Public Key</td>
-              <td>Contributors</td>
-              <td>Operator Fee (%)</td>
-              <td>Staking Requirement</td>
-              <td>Last Reward Height</td>
-              <td>Last Uptime Proof</td>
-              <td>Expiry Date UTC (Estimated)</td>
-          </tr>
-
-          {{#service_nodes_active}}
-          <tr>
-              <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
-              <td>{{num_contributors}}</td>
-              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
-              <td>{{staking_requirement}}</td>
-              <td>{{last_reward_at_block}}</td>
-              <td>{{last_uptime_proof}}</td>
-              <td>{{#expiration_date}}
-                    <span title="Service Node unlock in progress">🔓</span>
-                    {{expiration_date}} ({{expiration_time_relative}})
-                  {{/expiration_date}}
-                  {{^expiration_date}}Staking Infinitely{{/expiration_date}}
-              </td>
-          </tr>
-          {{/service_nodes_active}}
-          {{#service_nodes_active_more}}
-          <tr>
-              <td class="sn-more" colspan="7"><a href="/service_nodes">+ {{service_nodes_active_more}} more ↪</a></td>
-          </tr>
-          {{/service_nodes_active_more}}
-      </table>
-
-      <h2 style="margin-bottom: 0px" id="service-nodes-inactive">Inactive/Decommissioned Service Nodes <span class="sn-count">({{service_nodes_inactive_size}})</span></h2>
-      <h4 class="Subtitle">(These service nodes are currently decommissioned for failing network obligations, <span style="font-weight: bold; text-decoration: underline">are not earning rewards</span>, and face deregistration soon)</h4>
-      <div class="TitleDivider sn-inactive"></div>
-
-      <table style="width:100%">
-          <tr class="TableHeader">
-              <td>Public Key</td>
-              <td>Contributors</td>
-              <td>Operator Fee (%)</td>
-              <td>Decommission Height</td>
-              <td>Last Uptime Proof</td>
-              <td>Blocks until Dereg.</td>
-          </tr>
-
-          {{#service_nodes_inactive}}
-          <tr>
-              <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
-              <td>{{num_contributors}}</td>
-              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
-              <td>{{decommission_height}}</td>
-              <td>{{last_uptime_proof}}</td>
-              <td>{{#credit_remaining}}{{earned_downtime_blocks}} ({{earned_downtime}}){{/credit_remaining}}
-                  {{^credit_remaining}}None (deregistration imminent!){{/credit_remaining}}</td>
-          </tr>
-          {{/service_nodes_inactive}}
-          {{#service_nodes_inactive_more}}
-          <tr>
-              <td class="sn-more" colspan="7"><a href="/service_nodes#service-nodes-inactive">+ {{service_nodes_inactive_more}} more ↪</a></td>
-          </tr>
-          {{/service_nodes_inactive_more}}
-      </table>
+        and <span class="sn-count">{{service_nodes_active_size}}</span> active service nodes.</h3>
 
       <h2 style="margin-bottom: 0px" id="service-nodes-awaiting">Service Nodes Awaiting Contributions <span class="sn-count">({{service_nodes_awaiting_size}})</span></h2>
       <div class="TitleDivider sn-awaiting"></div>
@@ -118,6 +50,77 @@
           </tr>
           {{/service_nodes_awaiting_more}}
       </table>
+
+      <h2 style="margin-bottom: 0px" id="service-nodes-inactive">Inactive/Decommissioned Service Nodes <span class="sn-count">({{service_nodes_inactive_size}})</span></h2>
+      <h4 class="Subtitle">(These service nodes are currently decommissioned for failing network obligations, <span style="font-weight: bold; text-decoration: underline">are not earning rewards</span>, and face deregistration soon)</h4>
+      <div class="TitleDivider sn-inactive"></div>
+
+      <table style="width:100%">
+          <tr class="TableHeader">
+              <td>Public Key</td>
+              <td>Contributors</td>
+              <td>Operator Fee (%)</td>
+              <td>Decommission Height</td>
+              <td>Last Uptime Proof</td>
+              <td>Blocks until Dereg.</td>
+          </tr>
+
+          {{#service_nodes_inactive}}
+          <tr>
+              <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
+              <td>{{num_contributors}}</td>
+              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
+              <td>{{decommission_height}}</td>
+              <td>{{last_uptime_proof}}</td>
+              <td>{{#credit_remaining}}{{earned_downtime_blocks}} ({{earned_downtime}}){{/credit_remaining}}
+                  {{^credit_remaining}}None (deregistration imminent!){{/credit_remaining}}</td>
+          </tr>
+          {{/service_nodes_inactive}}
+          {{#service_nodes_inactive_more}}
+          <tr>
+              <td class="sn-more" colspan="7"><a href="/service_nodes#service-nodes-inactive">+ {{service_nodes_inactive_more}} more ↪</a></td>
+          </tr>
+          {{/service_nodes_inactive_more}}
+      </table>
+
+      <h2 style="margin-bottom: 0px">Active Service Nodes <span class="sn-count">({{service_nodes_active_size}})</span></h2>
+      <div class="TitleDivider sn-active"></div>
+
+      <table style="width:100%">
+          <tr class="TableHeader">
+              <td>Public Key</td>
+              <td>Contributors</td>
+              <td>Operator Fee (%)</td>
+              <td>Staking Requirement</td>
+              <td>Last Reward Height</td>
+              <td>Last Uptime Proof</td>
+              <td>Expiry Date UTC (Estimated)</td>
+          </tr>
+
+          {{#service_nodes_active}}
+          <tr>
+              <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
+              <td>{{num_contributors}}</td>
+              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
+              <td>{{staking_requirement}}</td>
+              <td>{{last_reward_at_block}}</td>
+              <td>{{last_uptime_proof}}</td>
+              <td>{{#expiration_date}}
+                    <span title="Service Node unlock in progress">🔓</span>
+                    {{expiration_date}} ({{expiration_time_relative}})
+                  {{/expiration_date}}
+                  {{^expiration_date}}Staking Infinitely{{/expiration_date}}
+              </td>
+          </tr>
+          {{/service_nodes_active}}
+          {{#service_nodes_active_more}}
+          <tr>
+              <td class="sn-more" colspan="7"><a href="/service_nodes">+ {{service_nodes_active_more}} more ↪</a></td>
+          </tr>
+          {{/service_nodes_active_more}}
+      </table>
+
+
 </div> <!-- Wrapper -->
 
 <div class="Wrapper">

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -24,8 +24,10 @@
               <td>{{staking_requirement}}</td>
               <td>{{last_reward_at_block}}</td>
               <td>{{last_uptime_proof}}</td>
-              <td>
-                  {{#expiration_date}}{{expiration_date}} ({{expiration_time_relative}}){{/expiration_date}}
+              <td>{{#expiration_date}}
+                    <span title="Service Node unlock in progress">🔓</span>
+                    {{expiration_date}} ({{expiration_time_relative}})
+                  {{/expiration_date}}
                   {{^expiration_date}}Staking Infinitely{{/expiration_date}}
               </td>
           </tr>
@@ -94,7 +96,13 @@
               <td>{{total_contributed}}</td>
               <td>{{total_reserved}}</td>
               <td>{{staking_requirement}}</td>
-              <td>{{expiration_date}} ({{expiration_time_relative}})</td>
+              <td>{{#expiration_date}}
+                    <span title="Service Node unlock in progress">🔓</span>
+                    {{expiration_date}} ({{expiration_time_relative}})
+                  {{/expiration_date}}
+                  {{^expiration_date}}Staking Infinitely{{/expiration_date}}
+              </td>
+
           </tr>
           {{/service_nodes_awaiting}}
           {{#service_nodes_awaiting_more}}

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -94,7 +94,14 @@
               <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
               <td>{{num_contributors}}</td>
               <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
+              {{#only_reserved_spots}}
+              <td title="All remaining contribution room is reserved for specific contributors">
+                  ⛔ {{open_for_contribution}}
+              </td>
+              {{/only_reserved_spots}}
+              {{^only_reserved_spots}}
               <td>{{open_for_contribution}}</td>
+              {{/only_reserved_spots}}
               <td>{{total_contributed}}</td>
               <td>{{total_reserved}}</td>
               <td>{{staking_requirement}}</td>


### PR DESCRIPTION
Rearranges the SN layout order plus various other small changes.  These are separated logically into individual commits.

Includes PR #9, fixes #2, fixes #8 

Live at https://loki.imaginary.stream and https://tn.imaginary.stream