### PR TITLE
Display service node winner and cumulative difficulty

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -973,131 +973,144 @@ render_checkpoints_html(bool add_header_and_footer)
 // detailed registration info, etc.), otherwise we just add basic info about the type of
 // transaction.
 void add_tx_service_node_metadata(mstch::map &context, const cryptonote::transaction &tx, bool detailed = false) {
-    if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
+    bool is_miner_tx = (tx.vin.size() && tx.vin[0].type() == typeid(cryptonote::txin_gen));
+    context["is_miner_tx"] = is_miner_tx;
+    if (is_miner_tx)
     {
-        tx_extra_service_node_register     register_;
-        tx_extra_tx_key_image_unlock       unlock_;
-        cryptonote::account_public_address contributor;
-        if (tx.type == cryptonote::txtype::state_change)
+        if (detailed)
         {
-            // Getting the hard fork version here is a bit tricker, so just try with v12 then if it
-            // fails, try with v11 instead (to capture older deregs).  Both still give back a
-            // state_change (for the older deregs, it translates the dereg_old into a state_change
-            // deregistration transparently).
-            tx_extra_service_node_state_change state_change;
-            context["is_state_change"] = true;
+            crypto::public_key winner      = cryptonote::get_service_node_winner_from_tx_extra(tx.extra);
+            context["service_node_winner"] = pod_to_hex(winner);
+        }
+    }
+    else
+    {
+        if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
+        {
+            tx_extra_service_node_register     register_;
+            tx_extra_tx_key_image_unlock       unlock_;
+            cryptonote::account_public_address contributor;
+            if (tx.type == cryptonote::txtype::state_change)
+            {
+                // Getting the hard fork version here is a bit tricker, so just try with v12 then if it
+                // fails, try with v11 instead (to capture older deregs).  Both still give back a
+                // state_change (for the older deregs, it translates the dereg_old into a state_change
+                // deregistration transparently).
+                tx_extra_service_node_state_change state_change;
+                context["is_state_change"] = true;
 #if 1
-            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
-            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
-               if (new_style)
-                    context["state_change_new_style"] = true;
+                bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
+                if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
+                   if (new_style)
+                        context["state_change_new_style"] = true;
 #else
-            if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
-                context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
+                if (get_service_node_state_change_from_tx_extra(tx.extra, state_change, blk.major_version)) {
+                    context["state_change_new_style"] = blk.major_version >= cryptonote::network_version_12_checkpointing;
 #endif
-                context["state_change_service_node_index"] = state_change.service_node_index;
-                context["state_change_block_height"] = state_change.block_height;
-                context[
-                    state_change.state == service_nodes::new_state::deregister ? "state_change_deregister" :
-                    state_change.state == service_nodes::new_state::decommission ? "state_change_decommission" :
-                    state_change.state == service_nodes::new_state::recommission ? "state_change_recommission" :
-                    state_change.state == service_nodes::new_state::ip_change_penalty ? "state_change_ip_change_penalty" :
-                    "state_change_unknown"] = true;
+                    context["state_change_service_node_index"] = state_change.service_node_index;
+                    context["state_change_block_height"] = state_change.block_height;
+                    context[
+                        state_change.state == service_nodes::new_state::deregister ? "state_change_deregister" :
+                        state_change.state == service_nodes::new_state::decommission ? "state_change_decommission" :
+                        state_change.state == service_nodes::new_state::recommission ? "state_change_recommission" :
+                        state_change.state == service_nodes::new_state::ip_change_penalty ? "state_change_ip_change_penalty" :
+                        "state_change_unknown"] = true;
+
+                    if (detailed) {
+                        // Try to get the quorum state to figure out the vote casters & target; unless very
+                        // recent, this requires lokid to be started with --store-quorum-history (PR #702)
+                        std::vector<std::string> quorum_nodes;
+                        COMMAND_RPC_GET_QUORUM_STATE::response response = {};
+                        rpc.get_quorum_state(response, state_change.block_height, state_change.block_height, static_cast<uint8_t>(service_nodes::quorum_type::obligations));
+
+                        if (response.status == "OK" && !response.quorums.empty()) {
+                            auto &quorum = response.quorums[0].quorum;
+                            if (state_change.service_node_index < quorum.workers.size())
+                                context["state_change_service_node_pubkey"] = quorum.workers[state_change.service_node_index];
+                            quorum_nodes = std::move(quorum.validators);
+                            context["state_change_have_pubkey_info"] = true;
+                        }
+
+                        auto &vote_array = get<mstch::array>(context.emplace("state_change_vote_array", mstch::array()).first->second);
+                        vote_array.reserve(state_change.votes.size());
+
+                        for (const auto &vote : state_change.votes)
+                        {
+                            mstch::map entry
+                            {
+                                {"state_change_voters_quorum_index", vote.validator_index},
+                                {"state_change_signature",           pod_to_hex(vote.signature)},
+                            };
+                            if (vote.validator_index < quorum_nodes.size())
+                                entry["state_change_voter_pubkey"] = quorum_nodes[vote.validator_index];
+
+                            vote_array.push_back(std::move(entry));
+                        }
+                    }
+                }
+                else {
+                    context["state_change_unknown"] = std::string{"unknown"};
+                }
+            }
+            else if (tx.type == cryptonote::txtype::key_image_unlock && get_tx_key_image_unlock_from_tx_extra(tx.extra, unlock_))
+            {
+                context["have_unlock_info"] = true;
+                context["unlock_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
+                if (detailed) {
+                    context["unlock_key_image"] = pod_to_hex(unlock_.key_image);
+                    context["unlock_signature"] = pod_to_hex(unlock_.signature);
+                }
+            }
+            else if (get_service_node_register_from_tx_extra(tx.extra, register_))
+            {
+                // TODO(doyle): We should add a url for jumping to the node,
+                // maybe. We only have information about the current state of
+                // the network, so previous expired nodes no longer can be
+                // accessed. This needs the store to db functionality.
+                // likewise for contributions, below.
+
+                context["have_register_info"]             = true;
+                context["register_service_node_pubkey"]   = extract_sn_pubkey(tx.extra);
+                context["register_portions_for_operator"] = portions_to_percent(register_.m_portions_for_operator);
 
                 if (detailed) {
-                    // Try to get the quorum state to figure out the vote casters & target; unless very
-                    // recent, this requires lokid to be started with --store-quorum-history (PR #702)
-                    std::vector<std::string> quorum_nodes;
-                    COMMAND_RPC_GET_QUORUM_STATE::response response = {};
-                    rpc.get_quorum_state(response, state_change.block_height, state_change.block_height, static_cast<uint8_t>(service_nodes::quorum_type::obligations));
+                    context["register_expiration_timestamp_friendly"]  = timestamp_to_str_gm(register_.m_expiration_timestamp);
+                    context["register_expiration_timestamp_relative"]  = get_human_time_ago(register_.m_expiration_timestamp, time(nullptr));
+                    context["register_expiration_timestamp"]  = register_.m_expiration_timestamp;
+                    context["register_signature"]             = pod_to_hex(register_.m_service_node_signature);
 
-                    if (response.status == "OK" && !response.quorums.empty()) {
-                        auto &quorum = response.quorums[0].quorum;
-                        if (state_change.service_node_index < quorum.workers.size())
-                            context["state_change_service_node_pubkey"] = quorum.workers[state_change.service_node_index];
-                        quorum_nodes = std::move(quorum.validators);
-                        context["state_change_have_pubkey_info"] = true;
-                    }
+                    auto &array = get<mstch::array>(context.emplace("register_array", mstch::array()).first->second);
+                    array.reserve(register_.m_public_spend_keys.size());
 
-                    auto &vote_array = get<mstch::array>(context.emplace("state_change_vote_array", mstch::array()).first->second);
-                    vote_array.reserve(state_change.votes.size());
-
-                    for (const auto &vote : state_change.votes)
+                    for (size_t i = 0; i < register_.m_public_spend_keys.size(); ++i)
                     {
-                        mstch::map entry
-                        {
-                            {"state_change_voters_quorum_index", vote.validator_index},
-                            {"state_change_signature",           pod_to_hex(vote.signature)},
-                        };
-                        if (vote.validator_index < quorum_nodes.size())
-                            entry["state_change_voter_pubkey"] = quorum_nodes[vote.validator_index];
+                      crypto::public_key const &spend_key = register_.m_public_spend_keys[i];
+                      crypto::public_key const &view_key =  register_.m_public_view_keys[i];
+                      auto portion = register_.m_portions[i];
 
-                        vote_array.push_back(std::move(entry));
+                      account_public_address address = {};
+                      address.m_spend_public_key     = spend_key;
+                      address.m_view_public_key      = view_key;
+
+                      mstch::map entry
+                      {
+                        {"register_address", get_account_address_as_str(nettype, false /*is_subaddress*/, address)},
+                        {"register_portions", portions_to_percent(portion)},
+                      };
+
+                      array.push_back(entry);
                     }
                 }
             }
-            else {
-                context["state_change_unknown"] = std::string{"unknown"};
+            else if (get_service_node_contributor_from_tx_extra(tx.extra, contributor))
+            {
+                context["have_contribution_info"]           = true;
+                context["contribution_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
+                context["contribution_address"]             = get_account_address_as_str(nettype, false /*is_subaddress*/, contributor);
+
+                uint64_t amount = get_amount_from_stake(tx, contributor);
+                context["contribution_amount"] = amount > 0 ? lokeg::lok_amount_to_str(amount, "{:0.9f}", true) : "<decode error>";
             }
-        }
-        else if (tx.type == cryptonote::txtype::key_image_unlock && get_tx_key_image_unlock_from_tx_extra(tx.extra, unlock_))
-        {
-            context["have_unlock_info"] = true;
-            context["unlock_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
-            if (detailed) {
-                context["unlock_key_image"] = pod_to_hex(unlock_.key_image);
-                context["unlock_signature"] = pod_to_hex(unlock_.signature);
-            }
-        }
-        else if (get_service_node_register_from_tx_extra(tx.extra, register_))
-        {
-            // TODO(doyle): We should add a url for jumping to the node,
-            // maybe. We only have information about the current state of
-            // the network, so previous expired nodes no longer can be
-            // accessed. This needs the store to db functionality.
-            // likewise for contributions, below.
-
-            context["have_register_info"]             = true;
-            context["register_service_node_pubkey"]   = extract_sn_pubkey(tx.extra);
-            context["register_portions_for_operator"] = portions_to_percent(register_.m_portions_for_operator);
-
-            if (detailed) {
-                context["register_expiration_timestamp_friendly"]  = timestamp_to_str_gm(register_.m_expiration_timestamp);
-                context["register_expiration_timestamp_relative"]  = get_human_time_ago(register_.m_expiration_timestamp, time(nullptr));
-                context["register_expiration_timestamp"]  = register_.m_expiration_timestamp;
-                context["register_signature"]             = pod_to_hex(register_.m_service_node_signature);
-
-                auto &array = get<mstch::array>(context.emplace("register_array", mstch::array()).first->second);
-                array.reserve(register_.m_public_spend_keys.size());
-
-                for (size_t i = 0; i < register_.m_public_spend_keys.size(); ++i)
-                {
-                  crypto::public_key const &spend_key = register_.m_public_spend_keys[i];
-                  crypto::public_key const &view_key =  register_.m_public_view_keys[i];
-                  auto portion = register_.m_portions[i];
-
-                  account_public_address address = {};
-                  address.m_spend_public_key     = spend_key;
-                  address.m_view_public_key      = view_key;
-
-                  mstch::map entry
-                  {
-                    {"register_address", get_account_address_as_str(nettype, false /*is_subaddress*/, address)},
-                    {"register_portions", portions_to_percent(portion)},
-                  };
-
-                  array.push_back(entry);
-                }
-            }
-        }
-        else if (get_service_node_contributor_from_tx_extra(tx.extra, contributor))
-        {
-			context["have_contribution_info"]           = true;
-			context["contribution_service_node_pubkey"] = extract_sn_pubkey(tx.extra);
-			context["contribution_address"]             = get_account_address_as_str(nettype, false /*is_subaddress*/, contributor);
-
-            uint64_t amount = get_amount_from_stake(tx, contributor);
-            context["contribution_amount"] = amount > 0 ? lokeg::lok_amount_to_str(amount, "{:0.9f}", true) : "<decode error>";
         }
     }
 }
@@ -1852,6 +1865,8 @@ show_block(uint64_t _blk_height)
             {"blk_size"             , fmt::format("{:0.4f}",
                                                   static_cast<double>(blk_size) / 1024.0)},
     };
+
+    add_tx_service_node_metadata(context, blk.miner_tx, true /*detailed*/);
     context.emplace("coinbase_txs", mstch::array{{txd_coinbase.get_mstch_map()}});
     context.emplace("blk_txs"     , mstch::array());
 

--- a/src/page.h
+++ b/src/page.h
@@ -1838,6 +1838,7 @@ show_block(uint64_t _blk_height)
 
     string blk_pow_hash_str = pod_to_hex(get_block_longhash(core_storage, blk, _blk_height, 0));
     uint64_t blk_difficulty = core_storage->get_db().get_block_difficulty(_blk_height);
+    uint64_t blk_cumulative_difficulty = core_storage->get_db().get_block_cumulative_difficulty(_blk_height);
 
     mstch::map context {
             {"testnet"              , testnet},
@@ -1858,12 +1859,12 @@ show_block(uint64_t _blk_height)
             {"delta_time"           , delta_time},
             {"blk_nonce"            , blk.nonce},
             {"blk_pow_hash"         , blk_pow_hash_str},
-            {"blk_difficulty"       , blk_difficulty},
+            {"blk_difficulty"       , lokeg::make_comma_sep_number(blk_difficulty)},
             {"age_format"           , age.second},
             {"major_ver"            , std::to_string(blk.major_version)},
             {"minor_ver"            , std::to_string(blk.minor_version)},
-            {"blk_size"             , fmt::format("{:0.4f}",
-                                                  static_cast<double>(blk_size) / 1024.0)},
+            {"blk_size"             , fmt::format("{:0.4f}", static_cast<double>(blk_size) / 1024.0)},
+            {"blk_cumulative_difficulty" , lokeg::make_comma_sep_number(blk_cumulative_difficulty)},
     };
 
     add_tx_service_node_metadata(context, blk.miner_tx, true /*detailed*/);

--- a/src/templates/block.html
+++ b/src/templates/block.html
@@ -36,7 +36,7 @@
 
         <tr>
             <td>Service Node Winner:</td><td><a href="/service_node/{{service_node_winner}}">{{service_node_winner}}</a></td>
-            <td></td>
+            <td>Cumulative Difficulty:</td><td>{{blk_cumulative_difficulty}}</td>
             <td></td>
         </tr>
     </table>

--- a/src/templates/block.html
+++ b/src/templates/block.html
@@ -33,6 +33,12 @@
             <td>Difficulty:</td><td>{{blk_difficulty}}</td>
             <td></td>
         </tr>
+
+        <tr>
+            <td>Service Node Winner:</td><td><a href="/service_node/{{service_node_winner}}">{{service_node_winner}}</a></td>
+            <td></td>
+            <td></td>
+        </tr>
     </table>
 
     <h2>Miner Reward Transaction</h3>

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -41,15 +41,21 @@
             <td>Fee (Per kB): {{tx_fee}} ({{payed_for_kB}})</td>
             <td>TX Size: {{tx_size}} kB</td>
         </tr>
+
         <tr>
-            <td>TX Version: {{tx_version}}</td>
+            <td>TX Version/Type: {{tx_version}}/{{tx_type_emoji}} {{tx_type}}</td>
             <td>No Of Confirmations: {{confirmations}}</td>
             <td>RingCT/RingCT Type:  {{#is_ringct}}Yes/{{rct_type}}{{/is_ringct}}{{^is_ringct}}No{{/is_ringct}}</td>
         </tr>
 
+        {{#is_miner_tx}}
         <tr>
-          <td>TX Type: {{tx_type_emoji}} {{tx_type}}</td>
+            <td>Service Node Winner:</td><td><a href="/service_node/{{service_node_winner}}">{{service_node_winner}}</a></td>
         </tr>
+
+        <tr>
+        </tr>
+        {{/is_miner_tx}}
 
         <tr>
             <td colspan="3" style="max-width:700px;word-wrap:break-word;">Extra: {{extra}}</td>


### PR DESCRIPTION
- Display the service node winner on the TX page if it's a miner transaction.
- Display the service node winner on the block page
- Display cumulative difficulty on block page
- Make difficulty on block page be comma separated

Change is live on: https://lokiblocks.com and https://lokitestnet.com
