### PR TITLE
Show fractional fees

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -584,10 +584,11 @@ page(MicroCore* _mcore,
 
 }
 
-int portions_to_percent(uint64_t portions)
+std::string portions_to_percent(uint64_t portions)
 {
-    int result = (int)(((portions / (double)STAKING_PORTIONS) * 100.0) + 0.5);
-    return result;
+    std::ostringstream os;
+    os << portions / (double)STAKING_PORTIONS * 100.;
+    return os.str();
 }
 
 time_t calculate_service_node_expiry_timestamp(uint64_t expiry_height)


### PR DESCRIPTION
Currently we round to an integer, but there are definitely fees
happening at values like 10.4% that we should be showing (which
are probably someone trying to be sneaky with the fee!).  The default
float output will only print out 5 significant digits (and will keep
integral fees as integers) so seems like a good approach.

![image](https://user-images.githubusercontent.com/4459524/67995608-12751600-fc2a-11e9-9689-9c1883874f11.png)
